### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       - "8443:8443"
       - "8843:8843"
       - "8880:8880"
+      - "3478:3478"
     volumes:
       - /etc/localtime:/etc/localtime:ro
       - /config/unifi/:/config


### PR DESCRIPTION
Added port 3478 (UDP) to enable Unifi Cloud Controller Access.